### PR TITLE
Enable https (via -s option)

### DIFF
--- a/config/generate-key-and-cert.sh
+++ b/config/generate-key-and-cert.sh
@@ -1,3 +1,5 @@
+cd "$(dirname "$0")"
+
 if test "x$1x" == "xx"; then
   FQDN="localhost"
 else

--- a/config/generate-key-and-cert.sh
+++ b/config/generate-key-and-cert.sh
@@ -1,0 +1,18 @@
+if test "x$1x" == "xx"; then
+  FQDN="localhost"
+else
+  FQDN=$1
+fi
+
+openssl genrsa 2048 > private.key
+openssl req -new -sha256 -key private.key -out cert.csr \
+  -subj "/C=FI/O=Intel OTC/CN=${FQDN}"
+
+openssl x509 \
+  -req \
+  -days 365 \
+  -in cert.csr \
+  -signkey private.key \
+  -out certificate.pem \
+
+rm cert.csr

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iot-rest-api-server",
   "version": "0.0.1",
-  "description": "Node.js API Server for IoTOS",
+  "description": "REST API Server for IoT",
   "repository": "https://github.com:01org/iot-rest-api-server",
   "main": "index.js",
   "scripts": {

--- a/test/oic-get
+++ b/test/oic-get
@@ -8,6 +8,14 @@ if test "x${API_SERVER_HOST}x" == "xx"; then
 	API_SERVER_HOST=localhost
 fi
 
+if test "x${API_SERVER_HTTPS}x" == "xx"; then
+  API_SERVER_PROTO=http
+  CERT=""
+else
+  API_SERVER_PROTO=https
+  CERT="--cacert ../config/certificate.pem "
+fi
+
 if test "x$1x" == "xx"; then
 	API_SERVER_URL="/a/light"
 else
@@ -16,4 +24,5 @@ fi
 
 echo $API_SERVER_HOST":"$API_SERVER_PORT $API_SERVER_URL
 
-curl --noproxy "*" -w "\nHTTP: %{http_code}\n" --no-buffer  http://${API_SERVER_HOST}:${API_SERVER_PORT}/api/oic${API_SERVER_URL}
+curl --noproxy "*" -w "\nHTTP: %{http_code}\n" --no-buffer ${CERT}\
+${API_SERVER_PROTO}://${API_SERVER_HOST}:${API_SERVER_PORT}/api/oic${API_SERVER_URL}

--- a/test/oic-put
+++ b/test/oic-put
@@ -8,6 +8,14 @@ if test "x${API_SERVER_HOST}x" == "xx"; then
 	API_SERVER_HOST=localhost
 fi
 
+if test "x${API_SERVER_HTTPS}x" == "xx"; then
+  API_SERVER_PROTO=http
+  CERT=""
+else
+  API_SERVER_PROTO=https
+  CERT="--cacert ../config/certificate.pem "
+fi
+
 if test "x$1x" == "xx"; then
 	API_SERVER_URL="/a/light"
 else
@@ -23,4 +31,5 @@ fi
 
 echo $API_SERVER_HOST":"$API_SERVER_PORT $API_SERVER_URL
 
-curl -X PUT --noproxy "*" -w "\nHTTP: %{http_code}\n" -H "Content-Type: application/json" -T ${API_SERVER_FILE} http://${API_SERVER_HOST}:${API_SERVER_PORT}/api/oic${API_SERVER_URL}
+curl -X PUT --noproxy "*" -w "\nHTTP: %{http_code}\n" -H "Content-Type: application/json" -T ${API_SERVER_FILE} ${CERT} \
+${API_SERVER_PROTO}://${API_SERVER_HOST}:${API_SERVER_PORT}/api/oic${API_SERVER_URL}


### PR DESCRIPTION
Added capability to run the iot-rest-api-server via https (using TLS).