### PR TITLE
Don't expose internal ID to the outside

### DIFF
--- a/oic/oic.js
+++ b/oic/oic.js
@@ -8,19 +8,15 @@ exports.parseRes = function(payload) {
   var link = {};
   var links = [];
 
-  if (typeof resource.sid != "undefined")
-    o.di = uuid.unparse(resource.sid);
+  if (typeof resource.id.deviceId != "undefined")
+    o.di = resource.id.deviceId;
 
-  if (typeof resource.uri != "undefined") {
-    link.href = resource.uri;
-    // NOTE: we add internal id as a fragment since we need it back
-    // on the subsequent request in order to identify the device uniqly
-    link.href = link.href + "?id=" + resource.id;
-  }
+  if (typeof resource.id.path != "undefined")
+    link.href = resource.id.path;
 
   // TODO: collect all ...
-  if (typeof resource.types[0] != "undefined")
-    link.rt = resource.types[0];
+  if (typeof resource.resourceTypes[0] != "undefined")
+    link.rt = resource.resourceTypes[0];
 
   if (typeof resource.interfaces[0] != "undefined")
     link.if = resource.interfaces[0];

--- a/test/oic-api-tester.js
+++ b/test/oic-api-tester.js
@@ -65,13 +65,13 @@ function onResourceFound(resources) {
 	for (var i = 0; i < resources.length; i++) {
 		var uri = resources[i].links[0].href;
 		console.log("%s : %s", resources[i].di, uri);
-		retrieveResources(uri, onResource, cliOptions.obs)
+		retrieveResources(uri + "?di=" + resources[i].di, onResource, cliOptions.obs)
 	}
 }
 
 function onResource(resource) {
 	console.log("--- onResource:");
-	console.log("%s : %s", resource.href, JSON.stringify(resource.properties));
+	console.log(resource)
 }
 
 function retrieveResources(uri, callback, obs) {


### PR DESCRIPTION
Details: Previously we exposed two IDs in the json discovery response

{"di":"abc","links":[{"href":"/a/high-level-example?id=xyz"}]}

and corresponsind HTTP GET (and PUT) would look like

GET /a/high-level-example?id=xyz

The change is to only expose one ID in the json discovery reponse

{"di":"abc","links":[{"href":"/a/high-level-example"}]}

and corresponsind HTTP GET (and PUT) would look like

GET /a/high-level-example?di=abc