### PR TITLE
Add support for running server as a socket-activated service

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var express = require('express');
 var path = require('path');
 var bodyParser = require('body-parser');
 var util = require('util');
+var systemd = require('systemd');
 var commandLineArgs = require('command-line-args');
 var device = require('iotivity-node')();
 var http, https, fs = null;
@@ -73,11 +74,13 @@ app.get('/', function(req, res) {
   res.render('main', {title: "IoT OS API Server", host: req.hostname, port: options.port});
 });
 
+var port = process.env.LISTEN_PID > 0 ? 'systemd' : options.port;
+
 if (options.https) {
-  https.createServer(httpsOptions, app).listen(options.port);
-  console.log('Running on https PORT: ' + options.port);
+  https.createServer(httpsOptions, app).listen(port);
+  console.log('Running on https PORT: ' + port);
 }
 else {
-  http.createServer(app).listen(options.port);
-  console.log('Running on PORT: ' + options.port);
+  http.createServer(app).listen(port);
+  console.log('Running on PORT: ' + port);
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.12.3",
     "iotivity-node": "^1.0.0-1",
     "jade": "^1.10.0",
+    "systemd": "^0.2.6",
     "uuid": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds support for running server as a socket-activated service using systemd module or stand-alone when started manually.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>