### PR TITLE
Handle retrieve requests with query options 

### DIFF
--- a/handlers/ocfHandler.js
+++ b/handlers/ocfHandler.js
@@ -147,7 +147,7 @@ var routes = function(req, res) {
             }
         }
 
-        DEV.retrieve({deviceId: req.query.di, path: req.path}).then(
+        DEV.retrieve({deviceId: req.query.di, path: req.path}, req.query).then(
             function(resource) {
                 if (req.query.obs != "undefined" && req.query.obs == true) {
                     req.on('close', function() {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Sakari Poussa",
   "license": "Apache-2.0",
   "dependencies": {
-    "iotivity-node": "^1.1.0-4"
+    "iotivity-node": "^1.1.0-5"
   },
   "devDependencies": {
     "gulp": "^3.8.11",


### PR DESCRIPTION
Add support to retrieve information with query options.

Example: A client can specify the units in fahrenheit for the requested temperature by use of a query parameter like below.

`GET /a/temperature-example?di=abc&units=F`

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
