### PR TITLE
ocfHandler: Call subscribe() to turn on global presence listening

### DIFF
--- a/handlers/ocfHandler.js
+++ b/handlers/ocfHandler.js
@@ -19,6 +19,15 @@ var discoveredResources = [];
 var discoveredDevices = [];
 var discoveredPlatforms = [];
 
+// Turn on global presence listening
+DEV.subscribe().then(
+    function() {
+        console.log("Subscribed for the presence notifications.");
+    },
+    function(error) {
+        console.log("device.subscribe() failed with: ", error);
+    });
+
 var routes = function(req, res) {
 
     if (req.path == '/res')


### PR DESCRIPTION
Turn on global presence listening flag by calling subscribe() method so that the client will handle device(i.e sensor server) presence notifications properly.

This fixes the issue with GET/PUT requests in REST server when the device(e.g fan sensor) presence is off and on.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>