### PR TITLE
ocfHandler: Disable automatic timeout behavior for the observe requests

### DIFF
--- a/handlers/ocfHandler.js
+++ b/handlers/ocfHandler.js
@@ -9,6 +9,7 @@ const PLATFORM_FOUND_EVENT = "platformfound";
 
 const timeoutValue = 5000; // 5s
 const timeoutStatusCode = 504; // Gateway Timeout
+const socketTimeoutValue = 0; // No timeout
 
 const okStatusCode = 200; // All right
 const noContentStatusCode = 204; // No content
@@ -175,6 +176,7 @@ var routes = function(req, res) {
                         req.query.obs = false;
                     });
                     res.writeHead(okStatusCode, {'Content-Type':'application/json'});
+                    req.setTimeout(socketTimeoutValue);
                     resource.addEventListener(RESOURCE_CHANGE_EVENT, observer);
                     resource.addEventListener(RESOURCE_DELETE_EVENT, deleteHandler);
                 } else {


### PR DESCRIPTION
The server timeout value is 2 minutes, and the sockets are destroyed
automatically if they time out, so this sets the timeout to 0 to disable
any kind of automatic timeout behavior for the observe requests as we
need to keep the connection alive.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>