### PR TITLE
ocfHandler: Remove the event listeners when the client connection is lost

### DIFF
--- a/handlers/ocfHandler.js
+++ b/handlers/ocfHandler.js
@@ -170,6 +170,8 @@ var routes = function(req, res) {
                 if (req.query.obs != "undefined" && req.query.obs == true) {
                     req.on('close', function() {
                         console.log("Client: close");
+                        resource.removeEventListener(RESOURCE_CHANGE_EVENT, observer);
+                        resource.removeEventListener(RESOURCE_DELETE_EVENT, deleteHandler);
                         req.query.obs = false;
                     });
                     res.writeHead(okStatusCode, {'Content-Type':'application/json'});


### PR DESCRIPTION
When the client connection is lost, we should remove all the event listeners
that were added for the resource on observe request.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>