### PR TITLE
Fix discovery issues

### DIFF
--- a/handlers/ocfHandler.js
+++ b/handlers/ocfHandler.js
@@ -93,6 +93,11 @@ var routes = function(req, res) {
             res.end(JSON.stringify(discoveredResources));
         });
 
+        res.on('close', function() {
+            console.log("Client: close");
+            DEV.removeEventListener(RESOURCE_FOUND_EVENT, onResourceFound);
+        });
+
         console.log("%s %s", req.method, req.url);
 
         discoveredResources.length = 0;
@@ -116,6 +121,11 @@ var routes = function(req, res) {
             res.end(JSON.stringify(discoveredDevices));
         });
 
+        res.on('close', function() {
+            console.log("Client: close");
+            DEV.removeEventListener(DEVICE_FOUND_EVENT, onDeviceFound);
+        });
+
         console.log("%s %s", req.method, req.url);
 
         discoveredDevices.length = 0;
@@ -137,6 +147,11 @@ var routes = function(req, res) {
             DEV.removeEventListener(PLATFORM_FOUND_EVENT, onPlatformFound);
             res.writeHead(okStatusCode, {'Content-Type': 'application/json'});
             res.end(JSON.stringify(discoveredPlatforms));
+        });
+
+        res.on('close', function() {
+            console.log("Client: close");
+            DEV.removeEventListener(PLATFORM_FOUND_EVENT, onPlatformFound);
         });
 
         console.log("%s %s", req.method, req.url);

--- a/handlers/ocfHandler.js
+++ b/handlers/ocfHandler.js
@@ -17,10 +17,6 @@ const internalErrorStatusCode = 500; // Internal error
 const badRequestStatusCode = 400; // Bad request
 const notFoundStatusCode = 404; // Not found
 
-var discoveredResources = [];
-var discoveredDevices = [];
-var discoveredPlatforms = [];
-
 // Turn on global presence listening
 DEV.subscribe().then(
     function() {
@@ -31,6 +27,10 @@ DEV.subscribe().then(
     });
 
 var routes = function(req, res) {
+    var discoveredResources = [];
+    var discoveredDevices = [];
+    var discoveredPlatforms = [];
+    var index;
 
     if (req.path == '/res')
         discoverResources(req, res);
@@ -51,15 +51,31 @@ var routes = function(req, res) {
 
     function onResourceFound(event) {
         var resource = OIC.parseRes(event);
+        // Do not add resource to the list, if we have already seen it.
+        for (index in discoveredResources) {
+             if (JSON.stringify(resource) ===
+                 JSON.stringify(discoveredResources[index]))
+                 return;
+        }
         discoveredResources.push(resource);
     }
 
     function onDeviceFound(event) {
+        // Do not add device to the list, if we have already seen it.
+        for (index in discoveredDevices) {
+             if (event.device.uuid === discoveredDevices[index].di)
+                 return;
+        }
         var device = OIC.parseDevice(event);
         discoveredDevices.push(device);
     }
 
     function onPlatformFound(event) {
+        // Do not add platform to the list, if we have already seen it.
+        for (index in discoveredPlatforms) {
+             if (event.platform.id === discoveredPlatforms[index].pi)
+                 return;
+        }
         var platform = OIC.parsePlatform(event);
         discoveredPlatforms.push(platform);
     }

--- a/oic/oic.js
+++ b/oic/oic.js
@@ -13,10 +13,12 @@ exports.parseRes = function(payload) {
     link.href = resource.id.path;
 
   // TODO: collect all ...
-  if (typeof resource.resourceTypes[0] != "undefined")
+  if (typeof resource.resourceTypes != "undefined" &&
+      typeof resource.resourceTypes[0] != "undefined")
     link.rt = resource.resourceTypes[0];
 
-  if (typeof resource.interfaces[0] != "undefined")
+  if (typeof resource.interfaces != "undefined" &&
+      typeof resource.interfaces[0] != "undefined")
     link.if = resource.interfaces[0];
 
   links.push(link);


### PR DESCRIPTION
This branch includes the following changes to the device/platform/resource discovery.

1. Changed the discovery functionality to be per request rather than global across all the requests. It fixes an inconsistent behaviour (appearing and disappearing resources) of the resource discovery.
2. Added fix to remove the attached OCF client event listeners when the connection gets terminated. 
3. Added checks to avoid duplicate entries of the same resources/devices/platforms in the discovered list.
4. Fixed a TypeError in parsing resource properties.