### PR TITLE
oic: Add policy parameter 'p' which indicates resource observable and discoverable flags

### DIFF
--- a/doc/oic.web-link.json
+++ b/doc/oic.web-link.json
@@ -21,6 +21,22 @@
       "type": "string",
       "description": "Interface - The interfaces supported by the resource referenced by the target URI"
     },
+    "p": {
+      "readOnly": true,
+      "description": "JSON object containing a Bitmap indicating observable and discoverable plus security and port",
+      "type": "object",
+      "properties": {
+        "bm": {
+          "type": "integer"
+        },
+        "sec": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "integer"
+        }
+      }
+    },
     "obs": {
       "type": "boolean",
       "description": "Specifies if the resource referenced by the target URIis observable or not",

--- a/oic/oic.js
+++ b/oic/oic.js
@@ -4,6 +4,7 @@ exports.parseRes = function(resource) {
   var o = {}; // resource object according to the OIC core spec.
   var link = {};
   var links = [];
+  var p = {}; // Policy Parameter.
 
   if (typeof resource.deviceId != "undefined")
     o.di = resource.deviceId;
@@ -19,6 +20,18 @@ exports.parseRes = function(resource) {
   if (typeof resource.interfaces != "undefined" &&
       typeof resource.interfaces[0] != "undefined")
     link.if = resource.interfaces[0];
+
+  if (resource.discoverable || resource.observable) {
+    p.bm = (0 | (resource.discoverable ? 1 << 0 : 0) |
+           (resource.observable ? 1 << 1 : 0));
+  }
+
+  p.secure = resource.secure;
+
+  if (typeof resource.port != "undefined")
+    p.port = resource.port;
+
+  link.p = p;
 
   links.push(link);
   o.links = links;


### PR DESCRIPTION
Add resource policy parameter which contains a Bitmap (bm) indicating observable and discoverable plus security and port.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>