### PR TITLE
ocfHandler: Fix direct resource observation

### DIFF
--- a/handlers/ocfHandler.js
+++ b/handlers/ocfHandler.js
@@ -205,8 +205,7 @@ var routes = function(req, res) {
                 var json = OIC.parseResource(resource);
                 res.write(json);
             } else {
-                if (resource.observable)
-                    resource.removeListener(RESOURCE_UPDATE_EVENT, observer);
+                resource.removeListener(RESOURCE_UPDATE_EVENT, observer);
                 resource.removeListener(RESOURCE_DELETE_EVENT, deleteHandler);
                 resource.removeListener(RESOURCE_ERROR_EVENT, errorHandler);
             }
@@ -224,18 +223,16 @@ var routes = function(req, res) {
                 if (req.query.obs != "undefined" && req.query.obs == true) {
                     req.on('close', function() {
                         console.log("Client: close");
-                        if (resource.observable)
-                            resource.removeListener(RESOURCE_UPDATE_EVENT, observer);
+                        resource.removeListener(RESOURCE_UPDATE_EVENT, observer);
                         resource.removeListener(RESOURCE_DELETE_EVENT, deleteHandler);
                         resource.removeListener(RESOURCE_ERROR_EVENT, errorHandler);
                         req.query.obs = false;
                     });
                     res.writeHead(okStatusCode, {'Content-Type':'application/json'});
                     req.setTimeout(socketTimeoutValue);
-                    if (resource.observable)
-                        resource.on(RESOURCE_UPDATE_EVENT, observer);
-                     resource.on(RESOURCE_DELETE_EVENT, deleteHandler);
-                     resource.on(RESOURCE_ERROR_EVENT, errorHandler);
+                    resource.on(RESOURCE_UPDATE_EVENT, observer);
+                    resource.on(RESOURCE_DELETE_EVENT, deleteHandler);
+                    resource.on(RESOURCE_ERROR_EVENT, errorHandler);
                 } else {
                     var json = OIC.parseResource(resource);
                     res.writeHead(okStatusCode, {'Content-Type':'application/json'});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Sakari Poussa",
   "license": "Apache-2.0",
   "dependencies": {
-    "iotivity-node": "^1.3.0-0"
+    "iotivity-node": "^1.3.0-2"
   },
   "bin": {
     "iot-rest-api-server": "bin/iot-rest-api-server.js"


### PR DESCRIPTION
Remove resource observable check since the direct retrieve returns an incomplete resource object and that doesn't contain the observable flag. 
Also, update iotivity-node dependency to 1.3.0-2 version which does no discovery on direct retrieve.